### PR TITLE
Fix markdown to plaintext conversion

### DIFF
--- a/apps/common/util/common.py
+++ b/apps/common/util/common.py
@@ -247,7 +247,7 @@ def markdown_to_plain_text(md: str) -> str:
     # 去除多余的空白字符（包括换行符、制表符等）
     text = re.sub(r'\s+', ' ', text)
     # 去除表单渲染
-    re.sub(r'<form_rander>[\s\S]*?<\/form_rander>', '', text)
+    text = re.sub(r'<form_rander>[\s\S]*?<\/form_rander>', '', text)
     # 去除首尾空格
     text = text.strip()
     return text


### PR DESCRIPTION
## Summary
- fix cleaning of `<form_rander>` blocks when converting markdown to text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68638c98bdc8832bb6d0ba6f34bde4af