### PR TITLE
Add license cache and version macros

### DIFF
--- a/apps/common/models/handle/impl/license_model_handle.py
+++ b/apps/common/models/handle/impl/license_model_handle.py
@@ -1,0 +1,12 @@
+from common.cache.file_cache import FileCache
+from common.models.handle.base_handle import IBaseModelHandle
+import os
+from smartdoc.const import PROJECT_DIR
+
+
+class LicenseModelHandle(IBaseModelHandle):
+    def get_model_dict(self):
+        cache_dir = os.path.join(PROJECT_DIR, 'data', 'cache', 'xpack_cache')
+        cache = FileCache(cache_dir, {})
+        return {'xpack_cache': cache}
+

--- a/apps/smartdoc/const.py
+++ b/apps/smartdoc/const.py
@@ -4,9 +4,22 @@ import os
 
 from .conf import ConfigManager
 
-__all__ = ['BASE_DIR', 'PROJECT_DIR', 'VERSION', 'CONFIG']
+__all__ = [
+    'BASE_DIR',
+    'PROJECT_DIR',
+    'VERSION',
+    'CONFIG',
+    'MAJOR_VERSION',
+    'MINOR_VERSION',
+    'PATCH_VERSION',
+]
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PROJECT_DIR = os.path.dirname(BASE_DIR)
-VERSION = '1.0.0'
+
+# Version is composed of major, minor and patch numbers
+MAJOR_VERSION = 1
+MINOR_VERSION = 0
+PATCH_VERSION = 0
+VERSION = f'{MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION}'
 CONFIG = ConfigManager.load_user_config(root_path=os.path.abspath('/opt/maxkb/conf'))

--- a/apps/smartdoc/settings/base.py
+++ b/apps/smartdoc/settings/base.py
@@ -208,3 +208,8 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Load custom model handles for DBModelManage
+MODEL_HANDLES = [
+    'common.models.handle.impl.license_model_handle.LicenseModelHandle',
+]

--- a/apps/users/serializers/user_serializers.py
+++ b/apps/users/serializers/user_serializers.py
@@ -50,9 +50,17 @@ class SystemSerializer(ApiMixin, serializers.Serializer):
     def get_profile():
         version = os.environ.get('MAXKB_VERSION')
         xpack_cache = DBModelManage.get_model('xpack_cache')
-        return {'version': version, 'IS_XPACK': hasattr(settings, 'IS_XPACK'),
-                'XPACK_LICENSE_IS_VALID': False if xpack_cache is None else xpack_cache.get('XPACK_LICENSE_IS_VALID',
-                                                                                            False)}
+        license_info = xpack_cache.get("LICENSE_INFO", {}) if xpack_cache is not None else {}
+        return {
+            "version": version,
+            "IS_XPACK": hasattr(settings, "IS_XPACK"),
+            "XPACK_LICENSE_IS_VALID": license_info.get("is_valid", False),
+            "LICENSED_TO": license_info.get("licensed_to"),
+            "LICENSE_EXPIRE_AT": license_info.get("expire_at"),
+            "LICENSE_VERSION": license_info.get("version"),
+            "LICENSE_SERIAL_NUMBER": license_info.get("serial_number"),
+            "LICENSE_NOTE": license_info.get("note"),
+        }
 
     @staticmethod
     def get_response_body_api():
@@ -60,8 +68,15 @@ class SystemSerializer(ApiMixin, serializers.Serializer):
             type=openapi.TYPE_OBJECT,
             required=[],
             properties={
-                'version': openapi.Schema(type=openapi.TYPE_STRING, title=_("System version number"),
-                                          description=_("System version number")),
+                'version': openapi.Schema(type=openapi.TYPE_STRING, title=_('System version number'),
+                                          description=_('System version number')),
+                'IS_XPACK': openapi.Schema(type=openapi.TYPE_BOOLEAN, title=_('XPack enable flag')),
+                'XPACK_LICENSE_IS_VALID': openapi.Schema(type=openapi.TYPE_BOOLEAN, title=_('Is license valid')),
+                'LICENSED_TO': openapi.Schema(type=openapi.TYPE_STRING, title=_('Licensed to'), description=_('Licensed user')),
+                'LICENSE_EXPIRE_AT': openapi.Schema(type=openapi.TYPE_INTEGER, title=_('License expire at')),
+                'LICENSE_VERSION': openapi.Schema(type=openapi.TYPE_STRING, title=_('License version')),
+                'LICENSE_SERIAL_NUMBER': openapi.Schema(type=openapi.TYPE_STRING, title=_('Serial number')),
+                'LICENSE_NOTE': openapi.Schema(type=openapi.TYPE_STRING, title=_('License note')),
             }
         )
 


### PR DESCRIPTION
## Summary
- add LicenseModelHandle for managing `xpack_cache`
- expose custom handle in settings
- define semantic version macros
- expand `/api/profile` serializer to return detailed license info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863943c1908832b8ffdaf22d8b21679